### PR TITLE
make PDF by default in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-paper.tex:
-	pandoc -s --filter pandoc-fignos --filter pandoc-citeproc --filter pandoc-crossref --natbib paper.md -o paper.tex --bibliography paper.bib --template revtex.template
-
-paper.pdf:
+paper.pdf: paper.tex
 	pdflatex paper.tex
 	bibtex paper
 	pdflatex paper.tex
+
+paper.tex:
+	pandoc -s --filter pandoc-fignos --filter pandoc-citeproc --filter pandoc-crossref --natbib paper.md -o paper.tex --bibliography paper.bib --template revtex.template


### PR DESCRIPTION
The default target is the first one in the Makefile, we also
add the correct dependency between the two targets.